### PR TITLE
Changing .cfg for factory reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mks500-configurator
 
-Consistently configure the MKS 500 gauges without the MKS software.
+For setting MKS500 gauges back to their default settings (LCLS-I config)
 
 Just plug the gauge electronics into your Windows laptop with a USB micro cable and double-click the executable.
 

--- a/settings.cfg
+++ b/settings.cfg
@@ -28,8 +28,8 @@ TIME NA Get and set the date and time.
 UPTIME NA Read the total Power ON Hours since the last power cycle or RST command.  
 VER NA Read FW version number               
 VTRAC NA Get the VacTrac statistics from the controller.         
-AO 1,1.0,1.0E-10,1.0,9.8,9.3 Get or set the analog output mode.         
-BL ON Set the gauge button lock or get the button lock state.     
+AO 1,1.0,1.0E-9,1.0,0.0,0.5 Get or set the analog output mode.         
+BL OFF Set the gauge button lock or get the button lock state.     
 CC NA Get or set the calibration curve.          
 CCID NA Get or set the calibration curve ID string.        
 CFM NA Get or set the pressure correction factor multiplier.        


### PR DESCRIPTION
Some old MKS 500 gauges in MFX's beamline in the XRT somehow became configured for LCLS-II during summer down and introduced issues into the vacuum system. I changed the .cfg to the default settings and we reset the gauges successfully last week (9/10/2025).

Jing and I wanted to create a separate repo with these changes because we don't want to bother updating the .py file on the master branch of the mks-500-configurator to work for either LCLS-I or -II. This is a quick and easy way to get this on github.